### PR TITLE
Address deprecated wasm-bindgen init api

### DIFF
--- a/src/workerHelpers.worker.js
+++ b/src/workerHelpers.worker.js
@@ -21,8 +21,8 @@
 // and temporary bugs so that you don't need to deal with them in your code.
 import initWbg, { wbg_rayon_start_worker } from '../../../';
 
-onmessage = async ({ data: { module, memory, receiver } }) => {
-  await initWbg({ module, memory });
+onmessage = async ({ data: { receiver, ...initData } }) => {
+  await initWbg(initData);
   postMessage(true);
   wbg_rayon_start_worker(receiver);
 };

--- a/src/workerHelpers.worker.js
+++ b/src/workerHelpers.worker.js
@@ -22,7 +22,7 @@
 import initWbg, { wbg_rayon_start_worker } from '../../../';
 
 onmessage = async ({ data: { module, memory, receiver } }) => {
-  await initWbg(module, memory);
+  await initWbg({ module, memory });
   postMessage(true);
   wbg_rayon_start_worker(receiver);
 };


### PR DESCRIPTION
This is the signature of the `__wbg_init` generated when using the latest version of wasm-bindgen.
```typescript
/**
* If `module_or_path` is {RequestInfo} or {URL}, makes a request and
* for everything else, calls `WebAssembly.instantiate` directly.
*
* @param {{ module_or_path: InitInput | Promise<InitInput>, memory?: WebAssembly.Memory, thread_stack_size?: number }} module_or_path - Passing `InitInput` directly is deprecated.
* @param {WebAssembly.Memory} memory - Deprecated.
*
* @returns {Promise<InitOutput>}
*/
export default function __wbg_init (module_or_path?: { module_or_path: InitInput | Promise<InitInput>, memory?: WebAssembly.Memory, thread_stack_size?: number } | InitInput | Promise<InitInput>, memory?: WebAssembly.Memory): Promise<InitOutput>;
```

We're currently using a deprecated api in our worker.js file. This causes the following warning to appear in the console when using the library
![image](https://github.com/user-attachments/assets/76e7f196-6199-4da2-bbd2-a1461c9d4cd6)

This PR fixes this issue by addressing the deprecated api