### PR TITLE
Don't listen `wasm_bindgen_worker_init` on main thread

### DIFF
--- a/src/workerHelpers.js
+++ b/src/workerHelpers.js
@@ -39,11 +39,13 @@ function waitForMsgType(target, type) {
 // and temporary bugs so that you don't need to deal with them in your code.
 import { initSync, wbg_rayon_start_worker } from '../../..';
 
-waitForMsgType(self, 'wasm_bindgen_worker_init').then(async data => {
-  initSync(data.init);
-  postMessage({ type: 'wasm_bindgen_worker_ready' });
-  wbg_rayon_start_worker(data.receiver);
-});
+if (name === "wasm_bindgen_worker") {
+  waitForMsgType(self, 'wasm_bindgen_worker_init').then(async data => {
+    initSync(data.init);
+    postMessage({ type: 'wasm_bindgen_worker_ready' });
+    wbg_rayon_start_worker(data.receiver);
+  });
+}
 
 export async function startWorkers(module, memory, builder) {
   const workerInit = {
@@ -70,7 +72,8 @@ export async function startWorkers(module, memory, builder) {
           import.meta.url
         ),
         {
-          type: 'module'
+          type: 'module',
+          name: 'wasm_bindgen_worker'
         }
       );
       worker.postMessage(workerInit);

--- a/src/workerHelpers.no-bundler.js
+++ b/src/workerHelpers.no-bundler.js
@@ -27,12 +27,14 @@ function waitForMsgType(target, type) {
 // We need to wait for a specific message because this file is used both
 // as a Worker and as a regular script, so it might receive unrelated
 // messages on the page.
-waitForMsgType(self, 'wasm_bindgen_worker_init').then(async data => {
-  const pkg = await import(data.mainJS);
-  await pkg.initSync(data.init);
-  postMessage({ type: 'wasm_bindgen_worker_ready' });
-  pkg.wbg_rayon_start_worker(data.receiver);
-});
+if (name === "wasm_bindgen_worker") {
+  waitForMsgType(self, 'wasm_bindgen_worker_init').then(async data => {
+    const pkg = await import(data.mainJS);
+    await pkg.initSync(data.init);
+    postMessage({ type: 'wasm_bindgen_worker_ready' });
+    pkg.wbg_rayon_start_worker(data.receiver);
+  });
+}
 
 export async function startWorkers(module, memory, builder) {
   const workerInit = {
@@ -51,7 +53,8 @@ export async function startWorkers(module, memory, builder) {
       let scriptBlob = await fetch(import.meta.url).then(r => r.blob());
       let url = URL.createObjectURL(scriptBlob);
       const worker = new Worker(url, {
-        type: 'module'
+        type: 'module',
+        name: 'wasm_bindgen_worker'
       });
       worker.postMessage(workerInit);
       await waitForMsgType(worker, 'wasm_bindgen_worker_ready');


### PR DESCRIPTION
Currently, `waitForMsgType(self, 'wasm_bindgen_worker_init').then()` will run on both main thread and worker thread. However, the main thread don't need to wait wasm_bindgen_worker_init, no such message will come in, the event listener will never be removed, resulting in memory leak.

I add the condition to make `waitForMsgType(self, 'wasm_bindgen_worker_init').then()` only runs on worker thread.

I've tested it on my real world application bundled with vite. No bundled version is not tested, but I believe it will work.